### PR TITLE
Revert "1.0.0-rc4"

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-  v1.0.0-rc4.tar.gz: ba166c907ade645ce4a41a2a20fbc13a8a6cd3ef
+  v1.0.0-rc3.tar.gz: 57d56045794ea107b76d21d105c697b76ba93fb7

--- a/runc.spec
+++ b/runc.spec
@@ -10,7 +10,7 @@
 %define provider_tld com
 %define project opencontainers
 %define	shortcommit 4dc5990
-%define pre rc4
+%define pre rc2
 
 Name:           runc
 Version:        1.0.0


### PR DESCRIPTION
Reverts OpenMandrivaAssociation/runc#4 does not work with docker